### PR TITLE
增加对网易云音乐开屏广告的屏蔽

### DIFF
--- a/Auto/URL REJECT.conf
+++ b/Auto/URL REJECT.conf
@@ -154,6 +154,7 @@
 ^https?://iadmatvideo.nosdn.127.net/ad - reject
 ^https?://haitaoad.nosdn.127.net/ad - reject
 ^https?://music.163.com/eapi/ad/ - reject
+^https?://p\d(c)?.music.126.net/\w+==/10995\d{13}\.jpg$ - reject
 
 // JD
 ^https?://111.13.29.201/client.action\?functionId=start - reject


### PR DESCRIPTION
虽然广告图片和正常图片混杂在一起，但多次抓包发现，正常图片总是带有参数，而广告图片总是光秃秃的。用 `$` 作为结尾，可以有效屏蔽开屏广告，且不会误杀正常图片。