### PR TITLE
增加对同花顺至尊版、杭州市市民卡开屏广告的屏蔽

### DIFF
--- a/Auto/Hostname.conf
+++ b/Auto/Hostname.conf
@@ -81,6 +81,7 @@ pic1cdn.cmbchina.com
 pic2.zhimg.com
 ress.dxpmedia.com
 sdkapp.uve.weibo.com
+smkmp.96225.com
 sso.ifanr.com
 static.api.m.panda.tv
 staticlive.douyucdn.cn

--- a/Auto/URL REJECT.conf
+++ b/Auto/URL REJECT.conf
@@ -472,6 +472,12 @@
 // Laosiji
 ^https?://api.laosiji.com/user/startpage/ - reject
 
+// Tonghuashun Pro
+^https?://adm.10jqka.com.cn/interface/getads\.php - reject
+
+// Hangzhoushi Shiminka
+^https?://smkmp.96225.com/smkcenter/ad/1.0.0/adBanner - reject
+
 // Other
 ^.+/ad(s|v)?.js - reject
 ^.+allOne.php\?ad_name=main_splash_ios - reject


### PR DESCRIPTION
同花顺至尊版 - https://itunes.apple.com/cn/app/id954724812
杭州市市民卡 - https://itunes.apple.com/cn/app/id917075932