### PR TITLE
remove all redundant and conflicting DOMAIN-SUFFIX rules

### DIFF
--- a/Surge.conf
+++ b/Surge.conf
@@ -76,34 +76,15 @@ USER-AGENT,geod*,DIRECT
 USER-AGENT,locationd*,DIRECT
 USER-AGENT,Maps*,DIRECT
 
-DOMAIN,aod.itunes.apple.com,DIRECT // Apple Music Streaming
-DOMAIN,api.smoot.apple.cn,DIRECT
-DOMAIN,api.smoot.apple.com,DIRECT
-DOMAIN,captive.apple.com,DIRECT
-DOMAIN,configuration.apple.com,DIRECT
-DOMAIN,gs-loc.apple.com,DIRECT // Maps
-DOMAIN,guzzoni.apple.com,DIRECT
-DOMAIN,mvod.itunes.apple.com,DIRECT // Apple Music Streaming
-DOMAIN,smp-device-content.apple.com,DIRECT
-DOMAIN,streamingaudio.itunes.apple.com,DIRECT // Apple Music Streaming
-DOMAIN,xp.apple.com,DIRECT
 DOMAIN-SUFFIX,aaplimg.com,DIRECT
 DOMAIN-SUFFIX,apple.co,DIRECT
 DOMAIN-SUFFIX,apple.com,DIRECT
 DOMAIN-SUFFIX,cdn-apple.com,DIRECT
-DOMAIN-SUFFIX,ess.apple.com,DIRECT
 DOMAIN-SUFFIX,icloud.com,DIRECT
 DOMAIN-SUFFIX,icloud-content.com,DIRECT
-DOMAIN-SUFFIX,itunes.apple.com,DIRECT
 DOMAIN-SUFFIX,itunes.com,DIRECT
-DOMAIN-SUFFIX,lcdn-locator.apple.com,DIRECT // Maps
-DOMAIN-SUFFIX,lcdn-registration.apple.com,DIRECT // Maps
-DOMAIN-SUFFIX,lookup-api.apple.com,DIRECT // Dictionary
-DOMAIN-SUFFIX,ls.apple.com,DIRECT // Maps
 DOMAIN-SUFFIX,me.com,DIRECT
 DOMAIN-SUFFIX,mzstatic.com,DIRECT // App Store & iTunes Images
-DOMAIN-SUFFIX,push.apple.com,DIRECT
-DOMAIN-SUFFIX,push-apple.com.akadns.net,DIRECT
 
 IP-CIDR,17.0.0.0/8,DIRECT,no-resolve
 
@@ -148,8 +129,6 @@ DOMAIN-SUFFIX,click.hunantv.com,REJECT
 DOMAIN-SUFFIX,da.mgtv.com,REJECT
 DOMAIN-SUFFIX,da.hunantv.com,REJECT
 DOMAIN-SUFFIX,res.hunantv.com,REJECT
-DOMAIN-SUFFIX,mp4.res.hunantv.com,REJECT
-DOMAIN-SUFFIX,x.da.hunantv.com,REJECT
 
 // Youku
 DOMAIN-SUFFIX,actives.youku.com,REJECT
@@ -189,7 +168,6 @@ DOMAIN-SUFFIX,store.tv.api.3g.youku.com,REJECT
 DOMAIN-SUFFIX,store.xl.api.3g.youku.com,REJECT
 DOMAIN-SUFFIX,tdrec.youku.com,REJECT
 DOMAIN-SUFFIX,test.ott.youku.com,REJECT
-DOMAIN-SUFFIX,test.sdk.m.youku.com,REJECT
 DOMAIN-SUFFIX,v.l.youku.com,REJECT
 DOMAIN-SUFFIX,val.api.youku.com,REJECT
 DOMAIN-SUFFIX,wan.youku.com,REJECT
@@ -214,14 +192,11 @@ IP-CIDR,223.87.182.52/32,REJECT,no-resolve
 DOMAIN-SUFFIX,api.game.letvstore.com,REJECT
 DOMAIN-SUFFIX,ark.letv.com,REJECT
 DOMAIN-SUFFIX,dc.letv.com,REJECT
-DOMAIN-SUFFIX,dev.dc.letv.com,REJECT
 DOMAIN-SUFFIX,fz.letv.com,REJECT
 DOMAIN-SUFFIX,g3.letv.com,REJECT
-DOMAIN-SUFFIX,letv.allyes.com,REJECT
 DOMAIN-SUFFIX,minisite.letv.com,REJECT
 DOMAIN-SUFFIX,msg.m.letv.com,REJECT
 DOMAIN-SUFFIX,n.mark.letv.com,REJECT
-DOMAIN-SUFFIX,plog.dc.letv.com,REJECT
 DOMAIN-SUFFIX,pro.hoye.letv.com,REJECT
 DOMAIN-SUFFIX,pro.letv.com,REJECT
 DOMAIN-SUFFIX,stat.letv.com,REJECT
@@ -237,9 +212,7 @@ DOMAIN-SUFFIX,ehg-youtube.hitbox.com,REJECT
 DOMAIN-SUFFIX,m-78.jp,REJECT
 DOMAIN-SUFFIX,nichibenren.or.jp,REJECT
 DOMAIN-SUFFIX,nicorette.co.kr,REJECT
-DOMAIN-SUFFIX,ssl-youtube.2cnt.net,REJECT
 DOMAIN-SUFFIX,youtube.112.2o7.net,REJECT
-DOMAIN-SUFFIX,youtube.2cnt.net,REJECT
 
 // Sohu
 DOMAIN-SUFFIX,epro.sogou.com,REJECT
@@ -283,25 +256,17 @@ DOMAIN-SUFFIX,ad.video.51togic.com,REJECT
 DOMAIN-SUFFIX,ads.cdn.tvb.com,REJECT
 DOMAIN-SUFFIX,biz5.kankan.com,REJECT
 DOMAIN-SUFFIX,c.algovid.com,REJECT
-DOMAIN-SUFFIX,cc.xtgreat.com,REJECT
-DOMAIN-SUFFIX,cm.zhiziyun.com,REJECT
 DOMAIN-SUFFIX,cms.laifeng.com,REJECT
-DOMAIN-SUFFIX,d.dsp.imageter.com,REJECT
 DOMAIN-SUFFIX,da.mmarket.com,REJECT
 DOMAIN-SUFFIX,data.vod.itc.cn,REJECT
 DOMAIN-SUFFIX,dotcounter.douyutv.com,REJECT
-DOMAIN-SUFFIX,files.adform.net,REJECT
 DOMAIN-SUFFIX,g.uusee.com,REJECT
 DOMAIN-SUFFIX,game.pps.tv,REJECT
 DOMAIN-SUFFIX,gcdn.2mdn.net,REJECT
-DOMAIN-SUFFIX,gentags.net,REJECT
 DOMAIN-SUFFIX,gg.jtertp.com,REJECT
 DOMAIN-SUFFIX,gug.ku6cdn.com,REJECT
 DOMAIN-SUFFIX,hp.smiler-ad.com,REJECT
 DOMAIN-SUFFIX,kooyum.com,REJECT
-DOMAIN-SUFFIX,kwflvcdn.000dn.com,REJECT
-DOMAIN-SUFFIX,l.fancyapi.com,REJECT
-DOMAIN-SUFFIX,l.ftx.fancyapi.com,REJECT
 DOMAIN-SUFFIX,ld.kuaigames.com,REJECT
 DOMAIN-SUFFIX,logstat.t.sfht.com,REJECT
 DOMAIN-SUFFIX,match.rtbidder.net,REJECT
@@ -315,24 +280,23 @@ DOMAIN-SUFFIX,pb.bi.gitv.tv,REJECT
 DOMAIN-SUFFIX,pop.uusee.com,REJECT
 DOMAIN-SUFFIX,pq.stat.ku6.com,REJECT
 DOMAIN-SUFFIX,qchannel01.cn,REJECT
+DOMAIN-SUFFIX,qchannel02.cn,REJECT
+DOMAIN-SUFFIX,qchannel03.cn,REJECT
+DOMAIN-SUFFIX,qchannel04.cn,REJECT
 DOMAIN-SUFFIX,rd.kuaigames.com,REJECT
 DOMAIN-SUFFIX,shizen-no-megumi.com,REJECT
 DOMAIN-SUFFIX,shrek.6.cn,REJECT
 DOMAIN-SUFFIX,simba.6.cn,REJECT
 DOMAIN-SUFFIX,st.vq.ku6.cn,REJECT
 DOMAIN-SUFFIX,statcounter.com,REJECT
-DOMAIN-SUFFIX,static.bshare.cn,REJECT
 DOMAIN-SUFFIX,static.duoshuo.com,REJECT
 DOMAIN-SUFFIX,static.g.ppstream.com,REJECT
 DOMAIN-SUFFIX,static.ku6.com,REJECT
 DOMAIN-SUFFIX,static8.pmadx.com,REJECT
 DOMAIN-SUFFIX,store.ptqy.gitv.tv,REJECT
-DOMAIN-SUFFIX,stuff.cdn.biddingx.com,REJECT
-DOMAIN-SUFFIX,t.cr-nielsen.com,REJECT
 DOMAIN-SUFFIX,t7z.cupid.ptqy.gitv.tv,REJECT
 DOMAIN-SUFFIX,traffic.uusee.com,REJECT
 DOMAIN-SUFFIX,union.6.cn,REJECT
-DOMAIN-SUFFIX,w.fancyapi.com,REJECT
 DOMAIN-SUFFIX,wa.gtimg.com,REJECT
 DOMAIN-SUFFIX,www.bfshan.cn,REJECT
 
@@ -373,7 +337,6 @@ DOMAIN-SUFFIX,impservice.dictvista.youdao.com,REJECT
 DOMAIN-SUFFIX,impservice.dictweb.youdao.com,REJECT
 DOMAIN-SUFFIX,impservice.dictword.youdao.com,REJECT
 DOMAIN-SUFFIX,impservice.mail.youdao.com,REJECT
-DOMAIN-SUFFIX,impservice.union.youdao.com,REJECT
 DOMAIN-SUFFIX,impservice2.youdao.com,REJECT
 DOMAIN-SUFFIX,impservicetest.dictapp.youdao.com,REJECT
 DOMAIN-SUFFIX,ir.mail.126.com,REJECT
@@ -404,10 +367,6 @@ DOMAIN-SUFFIX,tb104x.corp.youdao.com,REJECT
 DOMAIN-SUFFIX,union.youdao.com,REJECT
 DOMAIN-SUFFIX,wanproxy.127.net,REJECT
 DOMAIN-SUFFIX,wr.da.netease.com,REJECT
-DOMAIN-SUFFIX,www.qchannel01.cn,REJECT
-DOMAIN-SUFFIX,www.qchannel02.cn,REJECT
-DOMAIN-SUFFIX,www.qchannel03.cn,REJECT
-DOMAIN-SUFFIX,www.qchannel04.cn,REJECT
 DOMAIN-SUFFIX,ydpushserver.youdao.com,REJECT
 
 // 10000
@@ -440,7 +399,6 @@ DOMAIN-SUFFIX,gg.stargame.com,REJECT
 // 2345
 DOMAIN-SUFFIX,dl.2345.com,REJECT
 DOMAIN-SUFFIX,download.2345.com,REJECT
-DOMAIN-SUFFIX,jifendownload.2345.cn,REJECT
 DOMAIN-SUFFIX,wan.2345.com,REJECT
 
 // 360
@@ -505,7 +463,6 @@ DOMAIN-SUFFIX,appdownload.alicdn.com,REJECT
 DOMAIN-SUFFIX,atanx.alicdn.com,REJECT
 DOMAIN-SUFFIX,dorangesource.alicdn.com,REJECT
 DOMAIN-SUFFIX,hydra.alibaba.com,REJECT
-DOMAIN-SUFFIX,ifs.tanx.com,REJECT
 DOMAIN-SUFFIX,ipinyou.com,REJECT
 DOMAIN-SUFFIX,m.simaba.taobao.com,REJECT
 DOMAIN-SUFFIX,m-adash.m.taobao.com,REJECT
@@ -517,7 +474,6 @@ DOMAIN-SUFFIX,show.re.taobao.com,REJECT
 DOMAIN-SUFFIX,simba.taobao.com,REJECT
 DOMAIN-SUFFIX,strip.taobaocdn.com,REJECT
 DOMAIN-SUFFIX,tanx.com,REJECT
-DOMAIN-SUFFIX,tns.simba.taobao.com,REJECT
 DOMAIN-SUFFIX,userimg.qunar.com,REJECT
 DOMAIN-SUFFIX,wrating.com,REJECT
 DOMAIN-SUFFIX,yiliao.hupan.com,REJECT
@@ -535,14 +491,11 @@ DOMAIN-SUFFIX,adm3.autoimg.cn,REJECT
 DOMAIN-SUFFIX,adnewnc.app.autohome.com.cn,REJECT
 DOMAIN-SUFFIX,al.autohome.com.cn,REJECT
 DOMAIN-SUFFIX,applogapi.autohome.com.cn,REJECT
-DOMAIN-SUFFIX,at.mct01.com,REJECT
 DOMAIN-SUFFIX,c.autohome.com.cn,REJECT
 DOMAIN-SUFFIX,cmx.autohome.com.cn,REJECT
 DOMAIN-SUFFIX,comm.app.autohome.com.cn,REJECT
 DOMAIN-SUFFIX,dspmnt.autohome.com.cn,REJECT
-DOMAIN-SUFFIX,h.pcd.autohome.com.cn,REJECT
 DOMAIN-SUFFIX,pcd.autohome.com.cn,REJECT
-DOMAIN-SUFFIX,pmptrack-autohome.gentags.net,REJECT
 DOMAIN-SUFFIX,public.app.autohome.com.cn,REJECT
 DOMAIN-SUFFIX,push.app.autohome.com.cn,REJECT
 DOMAIN-SUFFIX,pv.alert.autohome.com.cn,REJECT
@@ -576,7 +529,6 @@ DOMAIN-SUFFIX,pc.videoclick.baidu.com,REJECT
 DOMAIN-SUFFIX,pos.baidu.com,REJECT
 DOMAIN-SUFFIX,push.zhanzhang.baidu.com,REJECT
 DOMAIN-SUFFIX,river.zhidao.baidu.com,REJECT
-DOMAIN-SUFFIX,s.cpro.baidu.com,REJECT
 DOMAIN-SUFFIX,wangmeng.baidu.com,REJECT
 
 // Book
@@ -585,20 +537,16 @@ DOMAIN-SUFFIX,ad.zhangyue.com,REJECT
 DOMAIN-SUFFIX,adm.easou.com,REJECT
 DOMAIN-SUFFIX,assets.easou.com,REJECT
 DOMAIN-SUFFIX,cj.qidian.com,REJECT
-DOMAIN-SUFFIX,da.hxspc.com,REJECT
 DOMAIN-SUFFIX,drdwy.com,REJECT
 DOMAIN-SUFFIX,e701.net,REJECT
 DOMAIN-SUFFIX,ethod.gzgmjcx.com,REJECT
 DOMAIN-SUFFIX,game.qidian.com,REJECT
 DOMAIN-SUFFIX,jisucn.com,REJECT
-DOMAIN-SUFFIX,m.12306media.com,REJECT
 DOMAIN-SUFFIX,o.if.qidian.com,REJECT
 DOMAIN-SUFFIX,picture.duokan.com,REJECT
 DOMAIN-SUFFIX,push.zhangyue.com,REJECT
 DOMAIN-SUFFIX,s1.cmfu.com,REJECT
 DOMAIN-SUFFIX,sanya1.com,REJECT
-DOMAIN-SUFFIX,sdk.cferw.com,REJECT
-DOMAIN-SUFFIX,stats.magicwindow.cn,REJECT
 DOMAIN-SUFFIX,tjlog.easou.com,REJECT
 DOMAIN-SUFFIX,tjlog.ps.easou.com,REJECT
 DOMAIN-SUFFIX,tongji.qidian.com,REJECT
@@ -638,10 +586,7 @@ DOMAIN-SUFFIX,sta.ganji.com,REJECT
 DOMAIN-SUFFIX,tralog.ganji.com,REJECT
 
 // Google
-DOMAIN-SUFFIX,ad.doubleclick.net,REJECT
 DOMAIN-SUFFIX,ads.google.com,REJECT
-DOMAIN-SUFFIX,cm.g.doubleclick.net,REJECT
-DOMAIN-SUFFIX,googleads.g.doubleclick.net,REJECT
 DOMAIN-SUFFIX,googleadservices.com,REJECT
 DOMAIN-SUFFIX,googleadsserving.cn,REJECT
 DOMAIN-SUFFIX,googleanalysis.mobi,REJECT
@@ -650,10 +595,6 @@ DOMAIN-SUFFIX,googlesyndication.com,REJECT
 DOMAIN-SUFFIX,googletagmanager.com,REJECT
 DOMAIN-SUFFIX,googletakes.com,REJECT
 DOMAIN-SUFFIX,mobileads.google.com,REJECT
-DOMAIN-SUFFIX,pubads.g.doubleclick.net,REJECT
-DOMAIN-SUFFIX,securepubads.g.doubleclick.net,REJECT
-DOMAIN-SUFFIX,static.doubleclick.net,REJECT
-DOMAIN-SUFFIX,static.googleadsserving.cn,REJECT
 
 // JD
 DOMAIN-SUFFIX,ads.union.jd.com,REJECT
@@ -693,9 +634,7 @@ DOMAIN-SUFFIX,tj.kugou.com,REJECT
 DOMAIN-SUFFIX,update.mobile.kugou.com,REJECT
 
 // Kuwo
-DOMAIN-SUFFIX,apk.shouji.koowo.com,REJECT
 DOMAIN-SUFFIX,deliver.kuwo.cn,REJECT
-DOMAIN-SUFFIX,g.koowo.com,REJECT
 DOMAIN-SUFFIX,g.kuwo.cn,REJECT
 DOMAIN-SUFFIX,game.kuwo.cn,REJECT
 DOMAIN-SUFFIX,kwmsg.kuwo.cn,REJECT
@@ -782,8 +721,6 @@ DOMAIN-SUFFIX,alitui.weibo.com,REJECT
 DOMAIN-SUFFIX,atm.sina.com,REJECT
 DOMAIN-SUFFIX,beacon.sina.com.cn,REJECT
 DOMAIN-SUFFIX,biz.weibo.com,REJECT
-DOMAIN-SUFFIX,c.biz.weibo.com,REJECT
-DOMAIN-SUFFIX,c.wcpt.biz.weibo.com,REJECT
 DOMAIN-SUFFIX,d1.sina.com.cn,REJECT
 DOMAIN-SUFFIX,d2.sina.com.cn,REJECT
 DOMAIN-SUFFIX,d3.sina.com.cn,REJECT
@@ -797,7 +734,6 @@ DOMAIN-SUFFIX,p4p.sina.com.cn,REJECT
 DOMAIN-SUFFIX,pay.mobile.sina.cn,REJECT
 DOMAIN-SUFFIX,pfp.sina.com.cn,REJECT
 DOMAIN-SUFFIX,promote.biz.weibo.cn,REJECT
-DOMAIN-SUFFIX,s.alitui.weibo.com,REJECT
 DOMAIN-SUFFIX,sax.sina.cn,REJECT
 DOMAIN-SUFFIX,sax.sina.com.cn,REJECT
 DOMAIN-SUFFIX,sdkapp.mobile.sina.cn,REJECT
@@ -807,26 +743,17 @@ DOMAIN-SUFFIX,trends.mobile.sina.cn,REJECT
 DOMAIN-SUFFIX,wbapp.mobile.sina.cn,REJECT
 DOMAIN-SUFFIX,wbclick.mobile.sina.cn,REJECT
 DOMAIN-SUFFIX,wbpctips.mobile.sina.cn,REJECT
-DOMAIN-SUFFIX,zc.biz.weibo.com,REJECT
 DOMAIN-SUFFIX,zymo.mps.weibo.com,REJECT
 
 // Sogou
 DOMAIN-SUFFIX,123.sogou.com,REJECT
-DOMAIN-SUFFIX,a1click.cpc.sogou.com,REJECT
 DOMAIN-SUFFIX,adsence.sogou.com,REJECT
 DOMAIN-SUFFIX,adstream.123.sogoucdn.com,REJECT
-DOMAIN-SUFFIX,alpha.brand.sogou.com,REJECT
 DOMAIN-SUFFIX,amfi.gou.sogou.com,REJECT
-DOMAIN-SUFFIX,athena.wan.sogou.com,REJECT
 DOMAIN-SUFFIX,bazinga.mse.sogou.com,REJECT
 DOMAIN-SUFFIX,brand.sogou.com,REJECT
 DOMAIN-SUFFIX,bsiet.husky.sogou.com,REJECT
-DOMAIN-SUFFIX,cdn.optaim.com,REJECT
-DOMAIN-SUFFIX,clk.optaim.com,REJECT
-DOMAIN-SUFFIX,cm.optaim.com,REJECT
-DOMAIN-SUFFIX,cpc.brand.sogou.com,REJECT
 DOMAIN-SUFFIX,cpc.sogou.com,REJECT
-DOMAIN-SUFFIX,demo.optaim.com,REJECT
 DOMAIN-SUFFIX,dl.wan.sogoucdn.com,REJECT
 DOMAIN-SUFFIX,fair.sogou.com,REJECT
 DOMAIN-SUFFIX,files2.sogou.com,REJECT
@@ -834,19 +761,9 @@ DOMAIN-SUFFIX,galaxy.sogoucdn.com,REJECT
 DOMAIN-SUFFIX,goto.sogou.com,REJECT
 DOMAIN-SUFFIX,ht.www.sogou.com,REJECT
 DOMAIN-SUFFIX,image.p4p.sogou.com,REJECT
-DOMAIN-SUFFIX,img.wan.sogou.com,REJECT
-DOMAIN-SUFFIX,imp.optaim.com,REJECT
-DOMAIN-SUFFIX,inte.sogou.com,REJECT
-DOMAIN-SUFFIX,irnvf.lu.sogou.com,REJECT
 DOMAIN-SUFFIX,iwan.sogou.com,REJECT
-DOMAIN-SUFFIX,kthxd.lu.sogou.com,REJECT
-DOMAIN-SUFFIX,lk.brand.sogou.com,REJECT
 DOMAIN-SUFFIX,lu.sogou.com,REJECT
 DOMAIN-SUFFIX,lu.sogoucdn.com,REJECT
-DOMAIN-SUFFIX,m.lu.sogou.com,REJECT
-DOMAIN-SUFFIX,mini.cpc.sogou.com,REJECT
-DOMAIN-SUFFIX,p.inte.sogou.com,REJECT
-DOMAIN-SUFFIX,p.lu.sogou.com,REJECT
 DOMAIN-SUFFIX,p3p.sogou.com,REJECT
 DOMAIN-SUFFIX,pb.sogou.com,REJECT
 DOMAIN-SUFFIX,pbd.sogou.com,REJECT
@@ -854,27 +771,10 @@ DOMAIN-SUFFIX,pv.focus.cn,REJECT
 DOMAIN-SUFFIX,pv.sogou.com,REJECT
 DOMAIN-SUFFIX,rd.e.sogou.com,REJECT
 DOMAIN-SUFFIX,rjgw.theta.sogou.com,REJECT
-DOMAIN-SUFFIX,sy.brand.sogou.com,REJECT
 DOMAIN-SUFFIX,theta.sogoucdn.com,REJECT
-DOMAIN-SUFFIX,tk.optaim.com,REJECT
-DOMAIN-SUFFIX,vjoz.lu.sogou.com,REJECT
-DOMAIN-SUFFIX,vps.inte.sogou.com,REJECT
 DOMAIN-SUFFIX,wan.sogou.com,REJECT
 DOMAIN-SUFFIX,wangmeng.sogou.com,REJECT
-DOMAIN-SUFFIX,wb.brand.sogou.com,REJECT
 DOMAIN-SUFFIX,web.sogou.com,REJECT
-DOMAIN-SUFFIX,www.optaim.com,REJECT
-DOMAIN-SUFFIX,ztrpm.lu.sogou.com,REJECT
-
-// Tanx
-DOMAIN-SUFFIX,a.tanx.com,REJECT
-DOMAIN-SUFFIX,cdn.tanx.com,REJECT
-DOMAIN-SUFFIX,cms.tanx.com,REJECT
-DOMAIN-SUFFIX,df.tanx.com,REJECT
-DOMAIN-SUFFIX,ecpm.tanx.com,REJECT
-DOMAIN-SUFFIX,p.tanx.com,REJECT
-DOMAIN-SUFFIX,pcookie.tanx.com,REJECT
-DOMAIN-SUFFIX,phs.tanx.com,REJECT
 
 // Teleplus
 DOMAIN-SUFFIX,guangzhuiyuan.com,REJECT
@@ -904,73 +804,39 @@ DOMAIN-SUFFIX,aiseet.aa.atianqi.com,REJECT
 DOMAIN-SUFFIX,aiseet.atianqi.com,REJECT
 DOMAIN-SUFFIX,analy.qq.com,REJECT
 DOMAIN-SUFFIX,boss.qzone.qq.com,REJECT
-DOMAIN-SUFFIX,c.gdt.qq.com,REJECT
-DOMAIN-SUFFIX,c.l.qq.com,REJECT
-DOMAIN-SUFFIX,c2.l.qq.com,REJECT
 DOMAIN-SUFFIX,ca.gtimg.com,REJECT
-DOMAIN-SUFFIX,canvas.gdt.qq.com,REJECT
-DOMAIN-SUFFIX,cb.l.qq.com,REJECT
-DOMAIN-SUFFIX,d.gdt.qq.com,REJECT
 DOMAIN-SUFFIX,d3g.qq.com,REJECT
 DOMAIN-SUFFIX,dp3.qq.com,REJECT
 DOMAIN-SUFFIX,e.qq.com,REJECT
 DOMAIN-SUFFIX,etg.qq.com,REJECT
 DOMAIN-SUFFIX,gdt.qq.com,REJECT
-DOMAIN-SUFFIX,hm.l.qq.com,REJECT
-DOMAIN-SUFFIX,i.gdt.qq.com,REJECT
 DOMAIN-SUFFIX,ios.bugly.qq.com,REJECT
 DOMAIN-SUFFIX,isdspeed.qq.com,REJECT
 DOMAIN-SUFFIX,l.qq.com,REJECT
-DOMAIN-SUFFIX,l2.l.qq.com,REJECT
 DOMAIN-SUFFIX,lb.gtimg.com,REJECT
-DOMAIN-SUFFIX,livem.l.qq.com,REJECT
-DOMAIN-SUFFIX,livep.l.aiseet.atianqi.com,REJECT
-DOMAIN-SUFFIX,livep.l.qq.com,REJECT
-DOMAIN-SUFFIX,lives.l.aiseet.atianqi.com,REJECT
-DOMAIN-SUFFIX,lives.l.qq.com,REJECT
-DOMAIN-SUFFIX,livew.l.qq.com,REJECT
-DOMAIN-SUFFIX,ls.l.qq.com,REJECT
 DOMAIN-SUFFIX,mcgi.v.qq.com,REJECT
 DOMAIN-SUFFIX,mdevstat.qqlive.qq.com,REJECT
-DOMAIN-SUFFIX,mi.gdt.qq.com,REJECT
 DOMAIN-SUFFIX,mini2015.qq.com,REJECT
 DOMAIN-SUFFIX,mmgr.gtimg.com,REJECT
-DOMAIN-SUFFIX,monitor.uu.qq.com,REJECT
-DOMAIN-SUFFIX,monitor-uu.play.aiseet.atianqi.com,REJECT
-DOMAIN-SUFFIX,news-l.play.aiseet.atianqi.com,REJECT
-DOMAIN-SUFFIX,otheve.play.aiseet.atianqi.com,REJECT
-DOMAIN-SUFFIX,othstr.play.aiseet.atianqi.com,REJECT
-DOMAIN-SUFFIX,p.l.qq.com,REJECT
-DOMAIN-SUFFIX,p2.l.qq.com,REJECT
 DOMAIN-SUFFIX,pgdt.gtimg.cn,REJECT
 DOMAIN-SUFFIX,pingjs.qq.com,REJECT
 DOMAIN-SUFFIX,pingma.qq.com,REJECT
 DOMAIN-SUFFIX,pingtcss.qq.com,REJECT
-DOMAIN-SUFFIX,p-l.play.aiseet.atianqi.com,REJECT
 DOMAIN-SUFFIX,pms.mb.qq.com,REJECT
 DOMAIN-SUFFIX,push.qq.com,REJECT
-DOMAIN-SUFFIX,q.i.gdt.qq.com,REJECT
 DOMAIN-SUFFIX,report.qq.com,REJECT
 DOMAIN-SUFFIX,res.imtt.qq.com,REJECT
 DOMAIN-SUFFIX,rh.qq.com,REJECT
-DOMAIN-SUFFIX,rm.gdt.qq.com,REJECT
-DOMAIN-SUFFIX,sdkconfig.play.aiseet.atianqi.com,REJECT
-DOMAIN-SUFFIX,t.l.qq.com,REJECT
 DOMAIN-SUFFIX,tajs.qq.com,REJECT
 DOMAIN-SUFFIX,taobao.qq.com,REJECT
 DOMAIN-SUFFIX,tcss.qq.com,REJECT
 DOMAIN-SUFFIX,tj.video.qq.com,REJECT
-DOMAIN-SUFFIX,t-l.play.aiseet.atianqi.com,REJECT
-DOMAIN-SUFFIX,u.l.qq.com,REJECT
 DOMAIN-SUFFIX,updatecenter.qq.com,REJECT
 DOMAIN-SUFFIX,uu.qq.com,REJECT
-DOMAIN-SUFFIX,v.gdt.qq.com,REJECT
 DOMAIN-SUFFIX,variety.tc.qq.com,REJECT
 DOMAIN-SUFFIX,vlive.qqvideo.tc.qq.com,REJECT
 DOMAIN-SUFFIX,vmindhls.tc.qq.com,REJECT
-DOMAIN-SUFFIX,vv.play.aiseet.atianqi.com,REJECT
 DOMAIN-SUFFIX,wb.gtimg.com,REJECT
-DOMAIN-SUFFIX,win.gdt.qq.com,REJECT
 DOMAIN-SUFFIX,wxsnsdy.tc.qq.com,REJECT
 DOMAIN-SUFFIX,wxsnsdy.video.qq.com,REJECT
 
@@ -1073,7 +939,6 @@ DOMAIN-SUFFIX,bss.pandora.xiaomi.com,REJECT
 DOMAIN-SUFFIX,counter.kingsoft.com,REJECT
 DOMAIN-SUFFIX,de.pandora.xiaomi.com,REJECT
 DOMAIN-SUFFIX,dvb.pandora.xiaomi.com,REJECT
-DOMAIN-SUFFIX,etl.xlmc.sandai.net,REJECT
 DOMAIN-SUFFIX,etl.xlmc.sec.miui.com,REJECT
 DOMAIN-SUFFIX,event.ksosoft.com,REJECT
 DOMAIN-SUFFIX,hot.browser.miui.com,REJECT
@@ -1116,7 +981,6 @@ DOMAIN-SUFFIX,uservoice.com,REJECT
 DOMAIN-SUFFIX,ws.progrss.yahoo.com,REJECT
 
 // Zhangyue
-DOMAIN-SUFFIX,m.ad.zhangyue.com,REJECT
 DOMAIN-SUFFIX,sys.zhangyue.com,REJECT
 
 // Zhihu
@@ -1373,7 +1237,6 @@ DOMAIN-SUFFIX,859377.com,REJECT
 DOMAIN-SUFFIX,85tgw.com,REJECT
 DOMAIN-SUFFIX,86.cc,REJECT
 DOMAIN-SUFFIX,860010.com,REJECT
-DOMAIN-SUFFIX,86file.megajoy.com,REJECT
 DOMAIN-SUFFIX,8800271.com.cn,REJECT
 DOMAIN-SUFFIX,88210212.com,REJECT
 DOMAIN-SUFFIX,8866786.com,REJECT
@@ -1545,7 +1408,6 @@ DOMAIN-SUFFIX,ad.spielothek.so,REJECT
 DOMAIN-SUFFIX,ad.spreaker.com,REJECT
 DOMAIN-SUFFIX,ad.thepaper.cn,REJECT
 DOMAIN-SUFFIX,ad.thisav.com,REJECT
-DOMAIN-SUFFIX,ad.unimhk.com,REJECT
 DOMAIN-SUFFIX,ad.userporn.com,REJECT
 DOMAIN-SUFFIX,ad.vidaroo.com,REJECT
 DOMAIN-SUFFIX,ad.walkgame.com,REJECT
@@ -1649,12 +1511,7 @@ DOMAIN-SUFFIX,adrotator.se,REJECT
 DOMAIN-SUFFIX,adrs.sdo.com,REJECT
 DOMAIN-SUFFIX,ads.feedly.com,REJECT
 DOMAIN-SUFFIX,ads.genieessp.com,REJECT
-DOMAIN-SUFFIX,ads.heyzap.com,REJECT
-DOMAIN-SUFFIX,ads.mobclix.com,REJECT
-DOMAIN-SUFFIX,ads.mopub.com,REJECT
-DOMAIN-SUFFIX,ads.mp.mydas.mobi,REJECT
 DOMAIN-SUFFIX,ads.newtentionassets.net,REJECT
-DOMAIN-SUFFIX,ads.nexage.com,REJECT
 DOMAIN-SUFFIX,ads.oneway.mobi,REJECT
 DOMAIN-SUFFIX,ads.oppomobile.com,REJECT
 DOMAIN-SUFFIX,ads.pof.com,REJECT
@@ -1775,7 +1632,6 @@ DOMAIN-SUFFIX,amazon-adsystem.com,REJECT
 DOMAIN-SUFFIX,ams.fx678.com,REJECT
 DOMAIN-SUFFIX,amz.steamprices.com,REJECT
 DOMAIN-SUFFIX,analysys.cn,REJECT
-DOMAIN-SUFFIX,analytics.126.net,DIRECT
 DOMAIN-SUFFIX,analytics.disneyinternational.com,REJECT
 DOMAIN-SUFFIX,analytics.mmosite.com,REJECT
 DOMAIN-SUFFIX,analytics.query.yahoo.com,REJECT
@@ -1789,7 +1645,6 @@ DOMAIN-SUFFIX,anysdk.com,REJECT
 DOMAIN-SUFFIX,aoodoo.weiphone.com,REJECT
 DOMAIN-SUFFIX,api.mobula.sdk.duapps.com,REJECT
 DOMAIN-SUFFIX,api.similarweb.com,REJECT
-DOMAIN-SUFFIX,api.talkingdata.com,REJECT
 DOMAIN-SUFFIX,api.userstyles.org,REJECT
 DOMAIN-SUFFIX,apkdo.com,REJECT
 DOMAIN-SUFFIX,appadhoc.com,REJECT
@@ -1908,14 +1763,12 @@ DOMAIN-SUFFIX,bdpuaw.com,REJECT
 DOMAIN-SUFFIX,bdtongfei.cn,REJECT
 DOMAIN-SUFFIX,beacon.krxd.net,REJECT
 DOMAIN-SUFFIX,beacon.tingyun.com,REJECT
-DOMAIN-SUFFIX,beap.gemini.yahoo.com,REJECT
 DOMAIN-SUFFIX,bebelait.com,REJECT
 DOMAIN-SUFFIX,becode.qiushibaike.com,REJECT
 DOMAIN-SUFFIX,beeho.site,REJECT
 DOMAIN-SUFFIX,behe.com,REJECT
 DOMAIN-SUFFIX,beintoo.com,REJECT
 DOMAIN-SUFFIX,bepolite.eu,REJECT
-DOMAIN-SUFFIX,besc.baidustatic.com,REJECT
 DOMAIN-SUFFIX,bfdcdn.com,REJECT
 DOMAIN-SUFFIX,biddingos.com,REJECT
 DOMAIN-SUFFIX,biddingx.com,REJECT
@@ -2060,11 +1913,9 @@ DOMAIN-SUFFIX,cnxad.com,REJECT
 DOMAIN-SUFFIX,cnxad.net,REJECT
 DOMAIN-SUFFIX,cnzhqs.com,REJECT
 DOMAIN-SUFFIX,cnzz.com,REJECT
-DOMAIN-SUFFIX,cnzz.kld666.com,REJECT
 DOMAIN-SUFFIX,cnzzlink.com,REJECT
 DOMAIN-SUFFIX,cocounion.com,REJECT
 DOMAIN-SUFFIX,code.kaixinjiehun.com,REJECT
-DOMAIN-SUFFIX,code.yqw88.com,REJECT
 DOMAIN-SUFFIX,code222.com,REJECT
 DOMAIN-SUFFIX,code668.com,REJECT
 DOMAIN-SUFFIX,codenow.cn,REJECT
@@ -2094,7 +1945,6 @@ DOMAIN-SUFFIX,cpm.amateurcommunity.de,REJECT
 DOMAIN-SUFFIX,cpm.cm.sandai.net,REJECT
 DOMAIN-SUFFIX,cpmchina.co,REJECT
 DOMAIN-SUFFIX,cpms.cc,REJECT
-DOMAIN-SUFFIX,cpro.baidustatic.com,REJECT
 DOMAIN-SUFFIX,cpro1.edushi.com,REJECT
 DOMAIN-SUFFIX,cpv.channelray,REJECT
 DOMAIN-SUFFIX,cpv6.com,REJECT
@@ -2144,7 +1994,6 @@ DOMAIN-SUFFIX,d.businessinsider.com,REJECT
 DOMAIN-SUFFIX,d.gossipcenter.com,REJECT
 DOMAIN-SUFFIX,d.ligatus.com,REJECT
 DOMAIN-SUFFIX,d.mingyihui.net,REJECT
-DOMAIN-SUFFIX,d.taomato.com,REJECT
 DOMAIN-SUFFIX,d.thelocal.com,REJECT
 DOMAIN-SUFFIX,d.tonghua5.com,REJECT
 DOMAIN-SUFFIX,d.xinshipu.com,REJECT
@@ -2223,7 +2072,6 @@ DOMAIN-SUFFIX,dis.crieto.com,REJECT
 DOMAIN-SUFFIX,display.digitalriver.com,REJECT
 DOMAIN-SUFFIX,display.superbay.net,REJECT
 DOMAIN-SUFFIX,distf.kankan.com,REJECT
-DOMAIN-SUFFIX,diyijs.duapp.com,REJECT
 DOMAIN-SUFFIX,djs.baomihua.com,REJECT
 DOMAIN-SUFFIX,dkdlsj.com,REJECT
 DOMAIN-SUFFIX,dleke.com,REJECT
@@ -2285,7 +2133,6 @@ DOMAIN-SUFFIX,duomeng.cn,REJECT
 DOMAIN-SUFFIX,duomeng.net,REJECT
 DOMAIN-SUFFIX,duomeng.org,REJECT
 DOMAIN-SUFFIX,duoyidd.com,REJECT
-DOMAIN-SUFFIX,dup.baidustatic.com,REJECT
 DOMAIN-SUFFIX,dushimj.com,REJECT
 DOMAIN-SUFFIX,duusuu.com,REJECT
 DOMAIN-SUFFIX,duyihu.net,REJECT
@@ -2366,7 +2213,6 @@ DOMAIN-SUFFIX,facebookma.cn,REJECT
 DOMAIN-SUFFIX,fan.twitch.tv,REJECT
 DOMAIN-SUFFIX,fancyapi.com,REJECT
 DOMAIN-SUFFIX,fansi365.com,REJECT
-DOMAIN-SUFFIX,farm.plista.com,REJECT
 DOMAIN-SUFFIX,fastable.com,REJECT
 DOMAIN-SUFFIX,fastapi.net,REJECT
 DOMAIN-SUFFIX,fastclick.com,REJECT
@@ -2446,7 +2292,6 @@ DOMAIN-SUFFIX,geo.cliphunter.com,REJECT
 DOMAIN-SUFFIX,geo.connexionsecure.com,REJECT
 DOMAIN-SUFFIX,geo.frtya.com,REJECT
 DOMAIN-SUFFIX,geo.frtyd.com,REJECT
-DOMAIN-SUFFIX,geobanner.adultfriendfinder.com,REJECT
 DOMAIN-SUFFIX,geobanner.alt.com,REJECT
 DOMAIN-SUFFIX,geobanner.friendfinder.com,REJECT
 DOMAIN-SUFFIX,geobanner.passion.com,REJECT
@@ -2533,7 +2378,6 @@ DOMAIN-SUFFIX,h9377c.com,REJECT
 DOMAIN-SUFFIX,haiwengji.net,REJECT
 DOMAIN-SUFFIX,haiyunpush.com,REJECT
 DOMAIN-SUFFIX,hanju18.net,REJECT
-DOMAIN-SUFFIX,hao123.com,REJECT
 DOMAIN-SUFFIX,hao123rt.com,REJECT
 DOMAIN-SUFFIX,hao61.net,REJECT
 DOMAIN-SUFFIX,haoghost.com,REJECT
@@ -2634,7 +2478,6 @@ DOMAIN-SUFFIX,im1.56zzw.com,REJECT
 DOMAIN-SUFFIX,ima3vpaid.appspot.com,REJECT
 DOMAIN-SUFFIX,imads.rediff.com,REJECT
 DOMAIN-SUFFIX,image.9duw.com,REJECT
-DOMAIN-SUFFIX,image.gentags.com,REJECT
 DOMAIN-SUFFIX,image.hh010.com,REJECT
 DOMAIN-SUFFIX,images.chinaz.com,REJECT
 DOMAIN-SUFFIX,images.gxsky.com,REJECT
@@ -2921,7 +2764,6 @@ DOMAIN-SUFFIX,magicwindow.cn,REJECT
 DOMAIN-SUFFIX,maibahe300cc.com,REJECT
 DOMAIN-SUFFIX,mainbx.com,REJECT
 DOMAIN-SUFFIX,maisoncherry.com,REJECT
-DOMAIN-SUFFIX,manads.static.olcdn.com,REJECT
 DOMAIN-SUFFIX,manage.wdfans.cn,REJECT
 DOMAIN-SUFFIX,maomaotang.com,REJECT
 DOMAIN-SUFFIX,market.178.com,REJECT
@@ -2994,7 +2836,6 @@ DOMAIN-SUFFIX,mobilityware.com,REJECT
 DOMAIN-SUFFIX,mobiorg8.com,REJECT
 DOMAIN-SUFFIX,mobisage.cn,REJECT
 DOMAIN-SUFFIX,mobvista.com,REJECT
-DOMAIN-SUFFIX,momo.popupad.cn,REJECT
 DOMAIN-SUFFIX,money.qz828.com,REJECT
 DOMAIN-SUFFIX,moodoocrv.com.cn,REJECT
 DOMAIN-SUFFIX,moogos.com,REJECT
@@ -3152,7 +2993,6 @@ DOMAIN-SUFFIX,pedailyu.com,REJECT
 DOMAIN-SUFFIX,pee.cn,REJECT
 DOMAIN-SUFFIX,phpad.cqnews.net,REJECT
 DOMAIN-SUFFIX,pic.0597kk.com,REJECT
-DOMAIN-SUFFIX,pic.111cn.net,REJECT
 DOMAIN-SUFFIX,pic.2u.com.cn,REJECT
 DOMAIN-SUFFIX,pic.ea3w.com,REJECT
 DOMAIN-SUFFIX,pic.fengniao.com,REJECT
@@ -3160,7 +3000,6 @@ DOMAIN-SUFFIX,picsinfog.com,REJECT
 DOMAIN-SUFFIX,pingbi.diudou.com,REJECT
 DOMAIN-SUFFIX,pingdom.net,REJECT
 DOMAIN-SUFFIX,pingshetrip.com,REJECT
-DOMAIN-SUFFIX,pixel.rubiconproject.com,REJECT
 DOMAIN-SUFFIX,pixel.wp.com,REJECT
 DOMAIN-SUFFIX,pixels.asia,REJECT
 DOMAIN-SUFFIX,pixfuture.net,REJECT
@@ -3219,8 +3058,6 @@ DOMAIN-SUFFIX,push.air-matters.com,REJECT
 DOMAIN-SUFFIX,pxene.com,REJECT
 DOMAIN-SUFFIX,pyzkk.com,REJECT
 DOMAIN-SUFFIX,qbyy010.com,REJECT
-DOMAIN-SUFFIX,qchannel01.cn,REJECT
-DOMAIN-SUFFIX,qchannel04.cn,REJECT
 DOMAIN-SUFFIX,qcjslm.com,REJECT
 DOMAIN-SUFFIX,qcl777.com,REJECT
 DOMAIN-SUFFIX,qd.dhzw.org,REJECT
@@ -3365,7 +3202,6 @@ DOMAIN-SUFFIX,serving-sys.com,REJECT
 DOMAIN-SUFFIX,sfloushi.com,REJECT
 DOMAIN-SUFFIX,sgbfjs.info,REJECT
 DOMAIN-SUFFIX,sgg.southcn.com,REJECT
-DOMAIN-SUFFIX,shaft.jebe.renren.com,REJECT
 DOMAIN-SUFFIX,shama5.com,REJECT
 DOMAIN-SUFFIX,shanghaironghua.com,REJECT
 DOMAIN-SUFFIX,shanglinli.com,REJECT
@@ -3435,7 +3271,6 @@ DOMAIN-SUFFIX,ssjpx.com,REJECT
 DOMAIN-SUFFIX,ssjy168.com,REJECT
 DOMAIN-SUFFIX,ssp.kssws.ks-cdn.com,REJECT
 DOMAIN-SUFFIX,ssp.zf313.com,REJECT
-DOMAIN-SUFFIX,sspapi.youxiaoad.com,REJECT
 DOMAIN-SUFFIX,sss.sege.xxx,REJECT
 DOMAIN-SUFFIX,sssvd.china.com,REJECT
 DOMAIN-SUFFIX,sstc360.com,REJECT
@@ -3448,13 +3283,11 @@ DOMAIN-SUFFIX,statcounter.com,REJECT
 DOMAIN-SUFFIX,static.ichehome.com,REJECT
 DOMAIN-SUFFIX,static.kinghost.com,REJECT
 DOMAIN-SUFFIX,static.oh100.com,REJECT
-DOMAIN-SUFFIX,static.plista.com,REJECT
 DOMAIN-SUFFIX,static.tucsonsentinel.com,REJECT
 DOMAIN-SUFFIX,static-xl9-ssl.xunlei.com,REJECT
 DOMAIN-SUFFIX,stats.chinaz.com,REJECT
 DOMAIN-SUFFIX,stats.developingperspective.com,REJECT
 DOMAIN-SUFFIX,stats.hosting24.com,REJECT
-DOMAIN-SUFFIX,stats.jpush.cn,REJECT
 DOMAIN-SUFFIX,stats.sitesuite.org,REJECT
 DOMAIN-SUFFIX,steelhousemedia.com,REJECT
 DOMAIN-SUFFIX,stervapoimenialena.info,REJECT
@@ -3472,7 +3305,6 @@ DOMAIN-SUFFIX,super.cat898.com,REJECT
 DOMAIN-SUFFIX,super.kdnet.net,REJECT
 DOMAIN-SUFFIX,supfast.net,REJECT
 DOMAIN-SUFFIX,surv.xbizmedia.com,REJECT
-DOMAIN-SUFFIX,survey.g.doubleclick.net,REJECT
 DOMAIN-SUFFIX,swa.gtimg.com,REJECT
 DOMAIN-SUFFIX,switchadhub.com,REJECT
 DOMAIN-SUFFIX,sxbhzs.net,REJECT
@@ -3509,7 +3341,6 @@ DOMAIN-SUFFIX,talkingdata.net,REJECT
 DOMAIN-SUFFIX,tangoutianxia.com,REJECT
 DOMAIN-SUFFIX,tansuotv.com,REJECT
 DOMAIN-SUFFIX,tanwanyx.com,REJECT
-DOMAIN-SUFFIX,tanx.com,REJECT
 DOMAIN-SUFFIX,tanzanite.infomine.com,REJECT
 DOMAIN-SUFFIX,taobaly.cn,REJECT
 DOMAIN-SUFFIX,taobaoaliyun.cn,REJECT
@@ -3551,7 +3382,6 @@ DOMAIN-SUFFIX,ticcdn.com,REJECT
 DOMAIN-SUFFIX,tiqcdn.com,REJECT
 DOMAIN-SUFFIX,tj.ali213.net,REJECT
 DOMAIN-SUFFIX,tjqonline.cn,REJECT
-DOMAIN-SUFFIX,tk.504pk.com,REJECT
 DOMAIN-SUFFIX,tkd777.cn,REJECT
 DOMAIN-SUFFIX,tmcs.net,REJECT
 DOMAIN-SUFFIX,tongqing2015.com,REJECT
@@ -3595,7 +3425,6 @@ DOMAIN-SUFFIX,u.cnzol.com,REJECT
 DOMAIN-SUFFIX,u.huoying666.com,REJECT
 DOMAIN-SUFFIX,u1.shuaiku.com,REJECT
 DOMAIN-SUFFIX,ua.badongo.com,REJECT
-DOMAIN-SUFFIX,ubmcmm.baidustatic.com,REJECT
 DOMAIN-SUFFIX,uc2.atobo.com.cn,REJECT
 DOMAIN-SUFFIX,uc610.com,REJECT
 DOMAIN-SUFFIX,ucaliyun.cn,REJECT
@@ -3655,7 +3484,6 @@ DOMAIN-SUFFIX,vi1.ku6img.net,REJECT
 DOMAIN-SUFFIX,vi1.souid.com,REJECT
 DOMAIN-SUFFIX,vichc.com,REJECT
 DOMAIN-SUFFIX,victorjx.com,REJECT
-DOMAIN-SUFFIX,video.plista.com,REJECT
 DOMAIN-SUFFIX,videondun.com,REJECT
 DOMAIN-SUFFIX,viglink.com,REJECT
 DOMAIN-SUFFIX,vipads.cn,REJECT
@@ -3987,7 +3815,6 @@ DOMAIN-SUFFIX,zybpj.com,REJECT
 DOMAIN-SUFFIX,zymro.com,REJECT
 DOMAIN-SUFFIX,zytwq.net,REJECT
 DOMAIN-SUFFIX,zzbaowen.com,REJECT
-DOMAIN-SUFFIX,zzimg.51.la,REJECT
 DOMAIN-SUFFIX,zzrcz.com,REJECT
 DOMAIN-SUFFIX,zzsx8.com,REJECT
 
@@ -4854,7 +4681,6 @@ DOMAIN-SUFFIX,cn,DIRECT
 DOMAIN-SUFFIX,12306.com,DIRECT
 DOMAIN-SUFFIX,126.net,DIRECT
 DOMAIN-SUFFIX,163.com,DIRECT
-DOMAIN-SUFFIX,360.cn,DIRECT
 DOMAIN-SUFFIX,360.com,DIRECT
 DOMAIN-SUFFIX,360buy.com,DIRECT
 DOMAIN-SUFFIX,360buyimg.com,DIRECT
@@ -4873,7 +4699,6 @@ DOMAIN-SUFFIX,alipay.com,DIRECT
 DOMAIN-SUFFIX,alipayobjects.com,DIRECT
 DOMAIN-SUFFIX,aliyun.com,DIRECT
 DOMAIN-SUFFIX,amap.com,DIRECT
-DOMAIN-SUFFIX,analytics.126.net,DIRECT
 DOMAIN-SUFFIX,apache.org,DIRECT
 DOMAIN-SUFFIX,appstore.com,DIRECT
 DOMAIN-SUFFIX,autonavi.com,DIRECT
@@ -4883,7 +4708,6 @@ DOMAIN-SUFFIX,battle.net,DIRECT
 DOMAIN-SUFFIX,bdimg.com,DIRECT
 DOMAIN-SUFFIX,bdstatic.com,DIRECT
 DOMAIN-SUFFIX,beatsbydre.com,DIRECT
-DOMAIN-SUFFIX,bilibili.cn,DIRECT
 DOMAIN-SUFFIX,bilibili.com,DIRECT
 DOMAIN-SUFFIX,bing.com,DIRECT
 DOMAIN-SUFFIX,caiyunapp.com,DIRECT
@@ -4915,7 +4739,6 @@ DOMAIN-SUFFIX,ecitic.net,DIRECT
 DOMAIN-SUFFIX,eclipse.org,DIRECT
 DOMAIN-SUFFIX,eudic.net,DIRECT
 DOMAIN-SUFFIX,ewqcxz.com,DIRECT
-DOMAIN-SUFFIX,exmail.qq.com,DIRECT
 DOMAIN-SUFFIX,feng.com,DIRECT
 DOMAIN-SUFFIX,fir.im,DIRECT
 DOMAIN-SUFFIX,frdic.com,DIRECT
@@ -4923,7 +4746,6 @@ DOMAIN-SUFFIX,fresh-ideas.cc,DIRECT
 DOMAIN-SUFFIX,geetest.com,DIRECT
 DOMAIN-SUFFIX,godic.net,DIRECT
 DOMAIN-SUFFIX,goodread.com,DIRECT
-DOMAIN-SUFFIX,google.cn,DIRECT
 DOMAIN-SUFFIX,gtimg.com,DIRECT
 DOMAIN-SUFFIX,haibian.com,DIRECT
 DOMAIN-SUFFIX,hao123.com,DIRECT
@@ -4968,7 +4790,6 @@ DOMAIN-SUFFIX,miaopai.com,DIRECT
 DOMAIN-SUFFIX,microsoft.com,DIRECT
 DOMAIN-SUFFIX,miui.com,DIRECT
 DOMAIN-SUFFIX,miwifi.com,DIRECT
-DOMAIN-SUFFIX,mob.com,DIRECT
 DOMAIN-SUFFIX,moke.com,DIRECT
 DOMAIN-SUFFIX,mxhichina.com,DIRECT
 DOMAIN-SUFFIX,myqcloud.com,DIRECT
@@ -5004,7 +4825,6 @@ DOMAIN-SUFFIX,rrmj.tv,DIRECT
 DOMAIN-SUFFIX,ruguoapp.com,DIRECT
 DOMAIN-SUFFIX,sandai.net,DIRECT
 DOMAIN-SUFFIX,sinaapp.com,DIRECT
-DOMAIN-SUFFIX,sinaimg.cn,DIRECT
 DOMAIN-SUFFIX,sinaimg.com,DIRECT
 DOMAIN-SUFFIX,smzdm.com,DIRECT
 DOMAIN-SUFFIX,snwx.com,DIRECT
@@ -5038,7 +4858,6 @@ DOMAIN-SUFFIX,v2ex.com,DIRECT
 DOMAIN-SUFFIX,vultr.com,DIRECT
 DOMAIN-SUFFIX,wandoujia.com,DIRECT
 DOMAIN-SUFFIX,weather.com,DIRECT
-DOMAIN-SUFFIX,weibo.cn,DIRECT
 DOMAIN-SUFFIX,weibo.com,DIRECT
 DOMAIN-SUFFIX,weico.cc,DIRECT
 DOMAIN-SUFFIX,weiphone.com,DIRECT
@@ -5078,7 +4897,6 @@ DOMAIN-SUFFIX,zimuzu.tv,DIRECT
 DOMAIN,client.amplifi.com,DIRECT
 DOMAIN,ip.bjango.com,DIRECT // iStat Menu IP Test
 DOMAIN-SUFFIX,alphassl.com,DIRECT
-DOMAIN-SUFFIX,edu.cn,DIRECT
 
 // Spark
 DOMAIN,api.amplitude.com,DIRECT


### PR DESCRIPTION
182 rules are removed

redundant DOMAIN-SUFFIX rules example: 
DOMAIN-SUFFIX,zhiziyun.com,REJECT
DOMAIN-SUFFIX,cm.zhiziyun.com,REJECT

conflicting rules example:
DOMAIN-SUFFIX,mob.com,REJECT
DOMAIN-SUFFIX,mob.com,DIRECT